### PR TITLE
Allow specifying OBJ path in Mesh.main

### DIFF
--- a/Mesh.py
+++ b/Mesh.py
@@ -229,9 +229,19 @@ class Mesh:
             aresta = aresta.proxima
         return faces
                 
-def main():
+def main(obj_path="Site.obj"):
+    """Load an OBJ file and start the interactive prompt.
+
+    Parameters
+    ----------
+    obj_path : str
+        Relative or absolute path to the OBJ file to load. Defaults to
+        ``"Site.obj"`` which is shipped with this project.
+    """
     mesh = Mesh()
-    mesh.abrirOBJ(r"C:\Users\RianA\Desktop\Computação Gráfica\Atividade3\Cube.obj")
+    # Use the provided path or the default local OBJ file. The previous code
+    # hard coded a Windows specific path which caused issues on other systems.
+    mesh.abrirOBJ(obj_path)
     mesh.printar()
     mesh.cicloExterno()
     print("\n\n\n")


### PR DESCRIPTION
## Summary
- update `Mesh.main` to accept an optional OBJ file path
- comment former Windows‑only default path

## Testing
- `python3 -m py_compile Mesh.py Display.py DisplayFile.py Transformacao.py`


------
https://chatgpt.com/codex/tasks/task_e_685d3ca2f288832f947d402492f2a3ee